### PR TITLE
Add bilingual landing page

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,1 +1,0 @@
-#Offical HiT3CH.

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,91 @@
+import { initLanguage, setLanguage } from './i18n.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initLanguage();
+
+  // Smooth scroll to solutions
+  document.querySelectorAll('[data-scroll]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const target = document.querySelector(btn.getAttribute('data-scroll'));
+      target?.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  // Language toggles
+  document.getElementById('lang-toggle')?.addEventListener('click', () => {
+    const next = document.documentElement.lang === 'sv' ? 'en' : 'sv';
+    setLanguage(next);
+  });
+  document.getElementById('lang-toggle-footer')?.addEventListener('click', () => {
+    const next = document.documentElement.lang === 'sv' ? 'en' : 'sv';
+    setLanguage(next);
+  });
+
+  // Modal logic
+  const modal = document.getElementById('contact-modal');
+  const openButtons = document.querySelectorAll('[data-modal-open]');
+  const closeButton = document.getElementById('modal-close');
+  const modalBg = document.getElementById('modal-bg');
+  const form = document.getElementById('contact-form');
+  const success = document.getElementById('form-success');
+
+  function openModal() {
+    modal.classList.remove('hidden');
+    modal.setAttribute('aria-hidden', 'false');
+    const focusable = modal.querySelector('input, textarea, button');
+    focusable?.focus();
+  }
+
+  function closeModal() {
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  openButtons.forEach(btn => btn.addEventListener('click', openModal));
+  closeButton?.addEventListener('click', closeModal);
+  modalBg?.addEventListener('click', e => { if (e.target === modalBg) closeModal(); });
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+
+  // Focus trap
+  modal.addEventListener('keydown', e => {
+    if (e.key !== 'Tab') return;
+    const focusable = modal.querySelectorAll('input, textarea, button');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  });
+
+  // Form submit
+  form?.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = new FormData(form);
+    if (!data.get('name') || !data.get('email')) {
+      alert('Name and email required');
+      return;
+    }
+    try {
+      const res = await fetch('https://formspree.io/f/your-id', {
+        method: 'POST',
+        headers: { 'Accept': 'application/json' },
+        body: data
+      });
+      if (res.ok) {
+        form.classList.add('hidden');
+        success.classList.remove('hidden');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+});

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -1,0 +1,129 @@
+export const translations = {
+  sv: {
+    meta_title: "HiT3CH – AI-automation för riktiga företag",
+    meta_desc: "Vi hjälper svenska bolag att effektivisera kundsupport, marknadsföring och arbetsflöden med AI.",
+    nav_solutions: "Lösningar",
+    nav_about: "Om oss",
+    nav_contact: "Kontakt",
+    hero_title: "AI-automation för riktiga företag",
+    hero_sub: "Vi automatiserar kundservice, marknadsföring och interna processer så att du kan fokusera på affären.",
+    hero_primary: "Boka möte",
+    hero_secondary: "Våra lösningar",
+    problem_title: "Från problem till lösning",
+    problem_card1_title: "Manuella processer",
+    problem_card1_text: "Tid och pengar slösas på repetitiva uppgifter.",
+    problem_card2_title: "Långsamma svar",
+    problem_card2_text: "Kunder väntar för länge på hjälp.",
+    problem_card3_title: "Fragmenterad data",
+    problem_card3_text: "Information sprids i olika system.",
+    solutions_title: "Lösningar",
+    solution1_title: "AI Kundsupport",
+    solution1_text: "Chatbots och e-post som svarar automatiskt.",
+    solution2_title: "AI Marknadsföring",
+    solution2_text: "Generera innehåll och kampanjer snabbare.",
+    solution3_title: "AI Arbetsflöden",
+    solution3_text: "Automatisera interna processer.",
+    how_title: "Så funkar det",
+    how_step1: "Boka demo",
+    how_step2: "Analys",
+    how_step3: "Implementering",
+    how_step4: "Optimering",
+    benefits_title: "Varför HiT3CH",
+    benefit1_title: "Snabb start",
+    benefit1_text: "Kom igång på veckor.",
+    benefit2_title: "Trygg data",
+    benefit2_text: "Allt hostas inom EU.",
+    benefit3_title: "Skalbar",
+    benefit3_text: "Lösningar växer med dig.",
+    benefit4_title: "Personlig support",
+    benefit4_text: "Vi finns här för dig.",
+    trust_gdpr: "GDPR-efterlevnad",
+    trust_eu: "EU-hosting",
+    trust_support: "Personlig support",
+    about_title: "Om HiT3CH",
+    about_text: "HiT3CH bygger praktiska AI-lösningar för nordiska företag.",
+    final_title: "Redo att börja?",
+    final_cta: "Boka möte",
+    form_name: "Namn",
+    form_company: "Företag",
+    form_email: "E-post",
+    form_message: "Meddelande",
+    form_submit: "Skicka",
+    form_success: "Tack! Vi hör av oss snart.",
+    footer_rights: "Alla rättigheter förbehållna."
+  },
+  en: {
+    meta_title: "HiT3CH – AI automation for real businesses",
+    meta_desc: "We help Nordic companies streamline support, marketing and workflows with AI.",
+    nav_solutions: "Solutions",
+    nav_about: "About",
+    nav_contact: "Contact",
+    hero_title: "AI automation for real businesses",
+    hero_sub: "We automate support, marketing and internal processes so you can focus on growth.",
+    hero_primary: "Book meeting",
+    hero_secondary: "Our solutions",
+    problem_title: "From problem to solution",
+    problem_card1_title: "Manual processes",
+    problem_card1_text: "Time and money wasted on repetitive tasks.",
+    problem_card2_title: "Slow responses",
+    problem_card2_text: "Customers wait too long for help.",
+    problem_card3_title: "Fragmented data",
+    problem_card3_text: "Information spread across systems.",
+    solutions_title: "Solutions",
+    solution1_title: "AI Support",
+    solution1_text: "Chatbots and email that answer automatically.",
+    solution2_title: "AI Marketing",
+    solution2_text: "Generate content and campaigns faster.",
+    solution3_title: "AI Workflows",
+    solution3_text: "Automate internal processes.",
+    how_title: "How it works",
+    how_step1: "Book demo",
+    how_step2: "Analysis",
+    how_step3: "Implementation",
+    how_step4: "Optimization",
+    benefits_title: "Why HiT3CH",
+    benefit1_title: "Fast start",
+    benefit1_text: "Go live in weeks.",
+    benefit2_title: "Secure data",
+    benefit2_text: "Everything hosted within the EU.",
+    benefit3_title: "Scalable",
+    benefit3_text: "Solutions grow with you.",
+    benefit4_title: "Personal support",
+    benefit4_text: "We are here for you.",
+    trust_gdpr: "GDPR compliant",
+    trust_eu: "EU hosting",
+    trust_support: "Personal support",
+    about_title: "About HiT3CH",
+    about_text: "HiT3CH builds practical AI solutions for Nordic companies.",
+    final_title: "Ready to start?",
+    final_cta: "Book meeting",
+    form_name: "Name",
+    form_company: "Company",
+    form_email: "Email",
+    form_message: "Message",
+    form_submit: "Send",
+    form_success: "Thanks! We'll be in touch soon.",
+    footer_rights: "All rights reserved."
+  }
+};
+
+export function setLanguage(lang) {
+  const selected = translations[lang] ? lang : 'sv';
+  localStorage.setItem('lang', selected);
+  document.documentElement.lang = selected;
+  const t = translations[selected];
+  document.title = t.meta_title;
+  const metaDesc = document.querySelector('meta[name="description"]');
+  if (metaDesc) metaDesc.setAttribute('content', t.meta_desc);
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (t[key]) el.textContent = t[key];
+  });
+  document.getElementById('lang-toggle')?.textContent = selected === 'sv' ? 'EN' : 'SV';
+  document.getElementById('lang-toggle-footer')?.textContent = selected === 'sv' ? 'EN' : 'SV';
+}
+
+export function initLanguage() {
+  const stored = localStorage.getItem('lang') || 'sv';
+  setLanguage(stored);
+}

--- a/docs/LICENSE
+++ b/docs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 HiT3CH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# HiT3CH
+
+Denna webbplats är en statisk engelsk/svensk landningssida som kan driftsättas på GitHub Pages.
+
+## Anpassa Formulär
+Byt ut Formspree-ID i `assets/app.js` genom att ersätta `your-id` med ditt riktiga ID.
+
+## Byt logotyp och text
+- Byt ut `assets/img/logo.png`, `assets/img/favicon.ico` och `assets/img/og-image.jpg`.
+- Uppdatera texter i `assets/i18n.js` för fler språk eller ändrade formuleringar.
+
+## Publicera på GitHub Pages
+1. Commit:a och pusha till `main`.
+2. Aktivera GitHub Pages under **Settings → Pages** och välj branch `main` och rotmapp `/`.
+3. Sidan nås sedan på `https://<ditt-användarnamn>.github.io/HiT3CH/`.
+
+## Redigera översättningar
+Alla texter ligger i `assets/i18n.js`. Lägg till eller ändra nycklar i både `sv` och `en`-objekten.
+
+## Licens
+Se `LICENSE` för licensinformation.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://example.com/docs/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="sv" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Vi hjälper svenska bolag att effektivisera kundsupport, marknadsföring och arbetsflöden med AI." />
+  <title data-i18n="meta_title">HiT3CH – AI-automation för riktiga företag</title>
+  <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico" />
+  <meta property="og:title" content="HiT3CH" />
+  <meta property="og:description" content="AI-automation för riktiga företag" />
+  <meta property="og:image" content="assets/img/og-image.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'sans-serif'] }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans bg-slate-950 text-slate-100">
+  <!-- Header -->
+  <header class="sticky top-0 z-50 backdrop-blur bg-slate-900/80">
+    <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+      <img src="assets/img/logo.png" alt="HiT3CH" class="h-8" />
+      <nav class="flex items-center space-x-6 text-sm">
+        <a href="#solutions" class="hover:text-sky-400" data-i18n="nav_solutions"></a>
+        <a href="#about" class="hover:text-sky-400" data-i18n="nav_about"></a>
+        <button id="lang-toggle" class="text-sky-400">EN</button>
+        <button data-modal-open class="bg-sky-500 px-4 py-2 rounded-md shadow-lg hover:scale-105 transition" data-i18n="nav_contact"></button>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero -->
+  <section class="relative overflow-hidden">
+    <div class="absolute inset-0 opacity-20" aria-hidden="true">
+      <svg class="w-full h-full" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="currentColor" stroke-width="0.5" />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid)" class="text-sky-500" />
+      </svg>
+    </div>
+    <div class="relative max-w-6xl mx-auto px-6 py-32 text-center space-y-6">
+      <h1 class="text-4xl md:text-6xl font-bold" data-i18n="hero_title"></h1>
+      <p class="text-lg md:text-xl text-slate-400 max-w-2xl mx-auto" data-i18n="hero_sub"></p>
+      <div class="flex justify-center space-x-4">
+        <button data-modal-open class="bg-sky-500 hover:bg-sky-600 px-6 py-3 rounded-md font-medium shadow-lg hover:scale-105 transition" data-i18n="hero_primary"></button>
+        <a href="#solutions" data-scroll="#solutions" class="px-6 py-3 rounded-md border border-sky-500 text-sky-400 hover:scale-105 transition" data-i18n="hero_secondary"></a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Problem to Solution -->
+  <section class="max-w-6xl mx-auto px-6 py-12 space-y-12" id="problem">
+    <h2 class="text-3xl font-bold text-center" data-i18n="problem_title"></h2>
+    <div class="grid md:grid-cols-3 gap-8">
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6"/></svg>
+        <h3 class="font-semibold" data-i18n="problem_card1_title"></h3>
+        <p class="text-slate-400" data-i18n="problem_card1_text"></p>
+      </div>
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 16V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2h14a2 2 0 002-2z"/></svg>
+        <h3 class="font-semibold" data-i18n="problem_card2_title"></h3>
+        <p class="text-slate-400" data-i18n="problem_card2_text"></p>
+      </div>
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.341A8 8 0 018.659 4.572m10.769 10.769A8 8 0 014.572 8.659m14.856 6.682a8 8 0 01-10.769-10.77"/></svg>
+        <h3 class="font-semibold" data-i18n="problem_card3_title"></h3>
+        <p class="text-slate-400" data-i18n="problem_card3_text"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Solutions -->
+  <section id="solutions" class="max-w-6xl mx-auto px-6 py-12 space-y-12">
+    <h2 class="text-3xl font-bold text-center" data-i18n="solutions_title"></h2>
+    <div class="grid md:grid-cols-3 gap-8">
+      <div class="space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 14l9-5-9-5-9 5 9 5z" /><path stroke-linecap="round" stroke-linejoin="round" d="M12 14l6.16-3.422A12.083 12.083 0 0112 21.5a12.083 12.083 0 01-6.16-10.922L12 14z" /></svg>
+        <h3 class="font-semibold" data-i18n="solution1_title"></h3>
+        <p class="text-slate-400" data-i18n="solution1_text"></p>
+      </div>
+      <div class="space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2"/></svg>
+        <h3 class="font-semibold" data-i18n="solution2_title"></h3>
+        <p class="text-slate-400" data-i18n="solution2_text"></p>
+      </div>
+      <div class="space-y-2">
+        <svg class="w-8 h-8 text-sky-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18v4H3zM3 9h18v4H3zM3 15h18v4H3z"/></svg>
+        <h3 class="font-semibold" data-i18n="solution3_title"></h3>
+        <p class="text-slate-400" data-i18n="solution3_text"></p>
+      </div>
+    </div>
+
+    <!-- How it works timeline -->
+    <div class="mt-12">
+      <h3 class="text-xl font-semibold mb-8 text-center" data-i18n="how_title"></h3>
+      <div class="grid grid-cols-4 text-center gap-4">
+        <div class="space-y-2">
+          <div class="bg-sky-500 text-white w-10 h-10 mx-auto rounded-full flex items-center justify-center">1</div>
+          <p class="text-sm" data-i18n="how_step1"></p>
+        </div>
+        <div class="space-y-2">
+          <div class="bg-sky-500 text-white w-10 h-10 mx-auto rounded-full flex items-center justify-center">2</div>
+          <p class="text-sm" data-i18n="how_step2"></p>
+        </div>
+        <div class="space-y-2">
+          <div class="bg-sky-500 text-white w-10 h-10 mx-auto rounded-full flex items-center justify-center">3</div>
+          <p class="text-sm" data-i18n="how_step3"></p>
+        </div>
+        <div class="space-y-2">
+          <div class="bg-sky-500 text-white w-10 h-10 mx-auto rounded-full flex items-center justify-center">4</div>
+          <p class="text-sm" data-i18n="how_step4"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Benefits and Trust -->
+  <section class="max-w-6xl mx-auto px-6 py-12 space-y-12" id="benefits">
+    <h2 class="text-3xl font-bold text-center" data-i18n="benefits_title"></h2>
+    <div class="grid md:grid-cols-4 gap-8">
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <h3 class="font-semibold" data-i18n="benefit1_title"></h3>
+        <p class="text-slate-400" data-i18n="benefit1_text"></p>
+      </div>
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <h3 class="font-semibold" data-i18n="benefit2_title"></h3>
+        <p class="text-slate-400" data-i18n="benefit2_text"></p>
+      </div>
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <h3 class="font-semibold" data-i18n="benefit3_title"></h3>
+        <p class="text-slate-400" data-i18n="benefit3_text"></p>
+      </div>
+      <div class="bg-slate-900 p-6 rounded-lg shadow-lg space-y-2">
+        <h3 class="font-semibold" data-i18n="benefit4_title"></h3>
+        <p class="text-slate-400" data-i18n="benefit4_text"></p>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-center space-x-8 pt-8 text-slate-400">
+      <span data-i18n="trust_gdpr"></span>
+      <span data-i18n="trust_eu"></span>
+      <span data-i18n="trust_support"></span>
+    </div>
+  </section>
+
+  <!-- About -->
+  <section id="about" class="max-w-3xl mx-auto px-6 py-12 text-center space-y-4">
+    <h2 class="text-3xl font-bold" data-i18n="about_title"></h2>
+    <p class="text-slate-400" data-i18n="about_text"></p>
+  </section>
+
+  <!-- Final CTA -->
+  <section class="bg-gradient-to-r from-sky-700 to-sky-500 py-20 text-center">
+    <h2 class="text-3xl md:text-4xl font-bold mb-6" data-i18n="final_title"></h2>
+    <button data-modal-open class="bg-slate-950 px-6 py-3 rounded-md shadow-lg hover:scale-105 transition text-slate-100" data-i18n="final_cta"></button>
+  </section>
+
+  <!-- Footer -->
+  <footer class="max-w-6xl mx-auto px-6 py-8 text-sm text-slate-400 flex flex-col md:flex-row md:items-center md:justify-between space-y-4 md:space-y-0">
+    <div class="space-x-4">
+      <a href="#solutions" class="hover:text-sky-400" data-i18n="nav_solutions"></a>
+      <a href="#about" class="hover:text-sky-400" data-i18n="nav_about"></a>
+      <a href="#benefits" class="hover:text-sky-400" data-i18n="benefits_title"></a>
+    </div>
+    <div class="flex items-center space-x-4">
+      <button id="lang-toggle-footer" class="text-sky-400">EN</button>
+      <span>© <span id="year"></span> HiT3CH. <span data-i18n="footer_rights"></span></span>
+    </div>
+  </footer>
+
+  <!-- Contact Modal -->
+  <div id="contact-modal" class="hidden fixed inset-0 bg-black/60 items-center justify-center" aria-hidden="true">
+    <div id="modal-bg" class="flex items-center justify-center w-full h-full">
+      <div class="bg-slate-900 p-8 rounded-xl max-w-md w-full shadow-xl space-y-4">
+        <div class="flex justify-between items-center">
+          <h3 class="text-xl font-semibold" data-i18n="nav_contact"></h3>
+          <button id="modal-close" class="text-slate-400 hover:text-slate-100">✕</button>
+        </div>
+        <form id="contact-form" class="space-y-4">
+          <div>
+            <label class="block text-sm mb-1" for="name" data-i18n="form_name"></label>
+            <input id="name" name="name" type="text" required class="w-full rounded-md border border-slate-700 bg-slate-800 px-4 py-2" />
+          </div>
+          <div>
+            <label class="block text-sm mb-1" for="company" data-i18n="form_company"></label>
+            <input id="company" name="company" type="text" class="w-full rounded-md border border-slate-700 bg-slate-800 px-4 py-2" />
+          </div>
+          <div>
+            <label class="block text-sm mb-1" for="email" data-i18n="form_email"></label>
+            <input id="email" name="email" type="email" required class="w-full rounded-md border border-slate-700 bg-slate-800 px-4 py-2" />
+          </div>
+          <div>
+            <label class="block text-sm mb-1" for="message" data-i18n="form_message"></label>
+            <textarea id="message" name="message" rows="4" class="w-full rounded-md border border-slate-700 bg-slate-800 px-4 py-2"></textarea>
+          </div>
+          <button type="submit" class="bg-sky-500 hover:bg-sky-600 text-white px-6 py-2 rounded-md" data-i18n="form_submit"></button>
+        </form>
+        <div id="form-success" class="hidden text-center" data-i18n="form_success"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Scripts -->
+  <script type="module" src="assets/app.js"></script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <!-- JSON-LD -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "HiT3CH",
+    "url": "https://example.com",
+    "logo": "assets/img/logo.png"
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create responsive Tailwind single-page site with Swedish/English support and dark theme
- Implement modal contact form posting to Formspree and storing language preference
- Remove binary image assets to keep repository text-only for initial commit

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a5a6041d68832781d7142f930625c3